### PR TITLE
Bugfix for TS Params and m

### DIFF
--- a/tsadar/core/modules/ts_params.py
+++ b/tsadar/core/modules/ts_params.py
@@ -348,9 +348,12 @@ class ThomsonParams(eqx.Module):
         for k in param_dict.keys():
             fitted_params[k] = {}
             for k2 in param_dict[k].keys():
-                if k2 == "m" and param_cfg[k]["fe"]["active"]:
-                    fitted_params[k][k2] = param_dict[k][k2]
-                    num_params += 1
+                if k2 == "m":
+                    if param_cfg[k]["fe"]["active"]:
+                        fitted_params[k][k2] = param_dict[k][k2]
+                        num_params += 1
+                    else:
+                        pass
                 elif k2 in ["f", "flm"]:
                     pass
                 elif param_cfg[k][k2]["active"]:


### PR DESCRIPTION
Was reaching and failing on evaluating the 2nd elif when `m` was inactive because that entry is classified with `fe`, now catching it and addressing that case explicitly 