### PR TITLE
Add a diagnostic data-provider interface (isolate OMEGA specifics)

### DIFF
--- a/tsadar/data/__init__.py
+++ b/tsadar/data/__init__.py
@@ -1,0 +1,62 @@
+"""Diagnostic data providers.
+
+A *data provider* maps a config dict to the ``(all_data, sa, all_axes)`` tuple
+that the forward/inverse pipeline consumes:
+
+- ``all_data``: plain dict of arrays (``e_data``, ``i_data``, ``e_amps``,
+  ``i_amps``, ``noiseE``, ``noiseI``, ...)
+- ``sa``: scattering angles / weights
+- ``all_axes``: spectral axes
+
+Everything downstream (``LossFunction``, ``ThomsonScatteringDiagnostic``,
+postprocessing) depends only on this contract -- not on how the data was
+produced. All OMEGA-specific behaviour (raw file loading, lineouts, background,
+throughput, calibration) lives *upstream* of this seam, inside the ``omega``
+provider.
+
+This is the extension point for adding a new diagnostic (e.g. NIF OTS) or for
+supplying preprocessed data instead of raw OMEGA files -- without touching the
+jax/AD model code. Implement a ``provider(config) -> (all_data, sa, all_axes)``
+function and register it::
+
+    from tsadar.data import register_data_provider
+
+    @register_data_provider("nif_ots")
+    def load_nif(config):
+        ...
+        return all_data, sa, all_axes
+
+then select it with ``config["data"]["provider"] = "nif_ots"`` (default:
+``"omega"``).
+"""
+from typing import Callable, Dict, Tuple
+
+DataProvider = Callable[[Dict], Tuple[Dict, Dict, Dict]]
+
+_DATA_PROVIDERS: Dict[str, DataProvider] = {}
+
+
+def register_data_provider(name: str) -> Callable[[DataProvider], DataProvider]:
+    """Register a ``config -> (all_data, sa, all_axes)`` provider under ``name``."""
+
+    def _register(fn: DataProvider) -> DataProvider:
+        _DATA_PROVIDERS[name.casefold()] = fn
+        return fn
+
+    return _register
+
+
+def get_data_provider(config: Dict) -> DataProvider:
+    """Return the provider selected by ``config["data"]["provider"]`` (default ``"omega"``)."""
+    name = config.get("data", {}).get("provider", "omega").casefold()
+    try:
+        return _DATA_PROVIDERS[name]
+    except KeyError:
+        raise KeyError(
+            f"Unknown data provider {name!r}. Registered providers: {sorted(_DATA_PROVIDERS)}. "
+            f"Register one with tsadar.data.register_data_provider."
+        )
+
+
+# Import built-in providers for their registration side effects.
+from . import omega  # noqa: E402,F401

--- a/tsadar/data/omega.py
+++ b/tsadar/data/omega.py
@@ -1,0 +1,38 @@
+"""OMEGA Thomson scattering data provider.
+
+Loads and preprocesses raw OMEGA data (file loading, background, throughput,
+lineouts, calibration) into the ``(all_data, sa, all_axes)`` contract. This is
+the reference implementation of the data-provider interface; see
+``tsadar.data`` for how to register a provider for another diagnostic.
+"""
+from typing import Dict, Tuple
+
+from . import prepare, register_data_provider
+
+
+@register_data_provider("omega")
+def load_omega_data(config: Dict) -> Tuple[Dict, Dict, Dict]:
+    """Load and preprocess OMEGA TS data into ``(all_data, sa, all_axes)``.
+
+    Handles the single-shot case as well as the multiplexed (rotated) angular
+    case where ``config["data"]["shotnum"]`` is a two-element list.
+    """
+    if isinstance(config["data"]["shotnum"], list):
+        startCCDsize = config["other"]["CCDsize"]
+        all_data, sa, all_axes = prepare.prepare_data(config, config["data"]["shotnum"][0])
+        config["other"]["CCDsize"] = startCCDsize
+        all_data2, _, _ = prepare.prepare_data(config, config["data"]["shotnum"][1])
+        all_data.update(
+            {
+                "e_data_rot": all_data2["e_data"],
+                "e_amps_rot": all_data2["e_amps"],
+                "rot_angle": config["data"]["shot_rot"],
+                "noiseE_rot": all_data2["noiseE"],
+            }
+        )
+
+        if config["other"]["extraoptions"]["spectype"] != "angular_full":
+            raise NotImplementedError("Muliplexed data fitting is only availible for angular data")
+    else:
+        all_data, sa, all_axes = prepare.prepare_data(config, config["data"]["shotnum"])
+    return all_data, sa, all_axes

--- a/tsadar/inverse/fitter.py
+++ b/tsadar/inverse/fitter.py
@@ -7,7 +7,7 @@ import mlflow
 
 from tsadar.inverse.loops import multirun_angular_optax, one_d_loop
 
-from ..data import prepare
+from ..data import get_data_provider
 from . import postprocess
 
 
@@ -119,8 +119,8 @@ def fit(config) -> Tuple[pd.DataFrame, float]:
     mlflow.set_tag("status", "preprocessing")
     config = _validate_inputs_(config)
 
-    # prepare data
-    all_data, sa, all_axes = load_data_for_fitting(config)
+    # prepare data via the configured diagnostic data provider (default: OMEGA)
+    all_data, sa, all_axes = get_data_provider(config)(config)
     sample_indices = np.arange(max(len(all_data["e_data"]), len(all_data["i_data"])))
     num_batches = len(sample_indices) // config["optimizer"]["batch_size"] or 1
     mlflow.log_metrics({"setup_time": round(time.time() - t1, 2)})
@@ -146,22 +146,10 @@ def fit(config) -> Tuple[pd.DataFrame, float]:
 
 
 def load_data_for_fitting(config):
-    if isinstance(config["data"]["shotnum"], list):
-        startCCDsize = config["other"]["CCDsize"]
-        all_data, sa, all_axes = prepare.prepare_data(config, config["data"]["shotnum"][0])
-        config["other"]["CCDsize"] = startCCDsize
-        all_data2, _, _ = prepare.prepare_data(config, config["data"]["shotnum"][1])
-        all_data.update(
-            {
-                "e_data_rot": all_data2["e_data"],
-                "e_amps_rot": all_data2["e_amps"],
-                "rot_angle": config["data"]["shot_rot"],
-                "noiseE_rot": all_data2["noiseE"],
-            }
-        )
+    """Backwards-compatible shim; dispatches to the configured data provider.
 
-        if config["other"]["extraoptions"]["spectype"] != "angular_full":
-            raise NotImplementedError("Muliplexed data fitting is only availible for angular data")
-    else:
-        all_data, sa, all_axes = prepare.prepare_data(config, config["data"]["shotnum"])
-    return all_data, sa, all_axes
+    Prefer ``tsadar.data.get_data_provider(config)(config)`` directly. Selects
+    the OMEGA loader by default; see ``tsadar.data`` to plug in another
+    diagnostic or supply preprocessed data.
+    """
+    return get_data_provider(config)(config)


### PR DESCRIPTION
## What

Introduces a **diagnostic data-provider interface** — the primary goal @almilder called out in #105: isolate the OMEGA-specific diagnostic specifics behind a minimal interface so others can plug in their own diagnostic (e.g. NIF OTS) or supply preprocessed data **without navigating the jax/AD model code**.

> _"the most important goal of this decomposition is to isolate the diagnostic specifics (calibrations, data loading, k-smearing)... so that other users can add on their own diagnostic specifics (e.g. NIF OTS)... or supply preprocessed data instead of raw OMEGA files."_

## How

The pipeline already had the right seam: everything downstream of data loading (`LossFunction`, `ThomsonScatteringDiagnostic`, the optimization loops, postprocessing) consumes only a plain `(all_data, sa, all_axes)` tuple. All OMEGA-specificity sits *upstream* of it. This PR makes that seam an explicit, registerable contract.

- **`tsadar/data/__init__.py`** — `register_data_provider(name)` decorator + `get_data_provider(config)`. A provider is any `config -> (all_data, sa, all_axes)` callable, selected by `config["data"]["provider"]` (default `"omega"`).
- **`tsadar/data/omega.py`** — the OMEGA loader (moved out of `fitter`) as the reference provider, self-registered as `"omega"`.
- **`fitter.fit`** resolves data via `get_data_provider(config)(config)`; `load_data_for_fitting` stays as a thin back-compat shim.

Adding a new diagnostic now takes zero model-code changes:

```python
from tsadar.data import register_data_provider

@register_data_provider("nif_ots")
def load_nif(config):
    ...                       # raw files OR preprocessed arrays — your choice
    return all_data, sa, all_axes
```
then `config["data"]["provider"] = "nif_ots"`.

## Behavior preservation

Configs **without** a `provider` key resolve to `"omega"` and follow the exact previous code path (incl. the multiplexed/rotated angular special case). Verified statically: registry resolves default→omega, empty-config→omega, unknown→clear `KeyError`; all intra-`tsadar` imports resolve; everything compiles. (Local jax is too old to run the suite — `import` smoke test + suite should be confirmed by a reviewer with a working env.)

## Open question for @almilder

**Supplying preprocessed data** is now supported by registering a trivial provider that returns your in-memory `(all_data, sa, all_axes)`. If you'd rather have a *built-in* `"preprocessed"` provider that reads from a file, what format do you want — `.npz`, `xarray`/`netCDF`, or just an in-memory dict passed programmatically? I left that out rather than guess the format.

## Sequencing / not in scope

- **Stacked on #106** (the coupling-break PR). Review/merge that first; this branch retargets to `main` automatically once it lands.
- Still to come per #105: **postprocessor extraction** (so users can swap visualization / plug into multi-diagnostic visualizers), folding **k-smearing** into the diagnostic layer (currently a dead inline flag in `calc_vs_data`), and the **Option A install extras** (note: `tsadar/__init__.py` eagerly imports `runner→fitter→optax/mlflow`, so a core-only install needs `__init__` import-hygiene, not just `pyproject` changes).

Toward #105.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
