### PR TITLE
refactor: Separate IRF from physics: pure functions + device-agnostc value objects

### DIFF
--- a/tsadar/core/instrument/__init__.py
+++ b/tsadar/core/instrument/__init__.py
@@ -1,0 +1,27 @@
+"""Device-dependent instrument model: everything applied to a spectrum after the physics.
+
+Modules here are organized by pipeline stage. Currently that is just the instrument
+response function; aperture weighting, notch filters, and pixel reduction move here as
+they are pulled out of ``core/physics/generate_spectra.py`` and
+``core/thomson_diagnostic.py``.
+
+Invariant for this package: no imports from the data or orchestration layers
+(``tsadar.data``, ``tsadar.inverse``, ``tsadar.forward``, ``tsadar.runner``), and no
+reading of a config dict. Callers translate their input deck into these value objects,
+which is what makes a new device a matter of construction rather than of matching
+OMEGA's deck layout.
+
+This sits inside the light-dependency forward kernel described in #105, in the
+"synthetic diagnostic" layer alongside ``core/thomson_diagnostic.py`` -- which is where
+that issue's target layering already places ``irf``, rather than under ``physics``.
+"""
+
+from .irf import AngularIRF, SpectrometerIRF, add_ATS_IRF, add_electron_IRF, add_ion_IRF
+
+__all__ = [
+    "AngularIRF",
+    "SpectrometerIRF",
+    "add_ATS_IRF",
+    "add_electron_IRF",
+    "add_ion_IRF",
+]

--- a/tsadar/core/instrument/irf.py
+++ b/tsadar/core/instrument/irf.py
@@ -5,10 +5,11 @@ This is device-dependent code, not physics. It holds both the value objects desc
 the same pipeline stage -- sibling stages (aperture weighting, notch filters, pixel
 reduction) get their own modules alongside this one.
 
-Nothing in ``tsadar.core.instrument`` may import from ``tsadar.utils`` or read a config
-dict. Translating an input deck into these value objects is the caller's job, so that
-porting TSADAR to a new diagnostic means constructing them directly rather than
-mimicking OMEGA's nested deck layout to reach a constructor.
+Nothing here may import from the data or orchestration layers (``tsadar.data``,
+``tsadar.inverse``, ``tsadar.forward``, ``tsadar.runner``) or read a config dict.
+Translating an input deck into these value objects is the caller's job, so that porting
+TSADAR to a new diagnostic means constructing them directly rather than mimicking
+OMEGA's nested deck layout to reach a constructor.
 """
 
 from dataclasses import dataclass

--- a/tsadar/core/instrument/irf.py
+++ b/tsadar/core/instrument/irf.py
@@ -1,35 +1,97 @@
+"""Instrument response function: spectral (and angular) blur, then binning onto pixels.
+
+This is device-dependent code, not physics. It holds both the value objects describing
+*this* detector's response and the routines that apply it, because those two belong to
+the same pipeline stage -- sibling stages (aperture weighting, notch filters, pixel
+reduction) get their own modules alongside this one.
+
+Nothing in ``tsadar.core.instrument`` may import from ``tsadar.utils`` or read a config
+dict. Translating an input deck into these value objects is the caller's job, so that
+porting TSADAR to a new diagnostic means constructing them directly rather than
+mimicking OMEGA's nested deck layout to reach a constructor.
+"""
+
+from dataclasses import dataclass
 from typing import Tuple
+
+import numpy as np
 from jax import numpy as jnp, vmap
 
 
-def add_ATS_IRF(config, sas, lamAxisE, modlE, amps, TSins) -> Tuple[jnp.ndarray, jnp.ndarray]:
+@dataclass(frozen=True)
+class SpectrometerIRF:
+    """Response of a 1D spectrometer: spectral blur, then binning onto detector pixels.
+
+    Every field is required. There are no defaults on purpose: a default for
+    ``n_spectral_pixels`` would be silently correct on OMEGA and silently wrong
+    elsewhere, which is the failure mode this module exists to prevent.
+
+    This carries only *static* configuration, so it is an ordinary dataclass rather than
+    an ``equinox`` module -- nothing here is a traced JAX leaf. The fitted instrument
+    nuisance parameters (``amp1``/``amp2``/``amp3``) still arrive separately via the
+    parameter tree.
+
+    Args:
+        spect_stddev: Gaussian spectral IRF standard deviation, in nm. A falsy value
+            means "no spectral IRF" and the convolution is skipped (ion channel only).
+        n_spectral_pixels: Number of wavelength pixels on the detector. The convolved
+            spectrum is computed on a fine grid and averaged down onto this many bins.
+        normalize: Normalization mode. ``0`` scales the spectrum to the measured data
+            amplitude; ``> 0`` normalizes each wing to unity and scales it by the fitted
+            ``amp1``/``amp2``.
+    """
+
+    spect_stddev: float
+    n_spectral_pixels: int
+    normalize: int
+
+
+@dataclass(frozen=True, eq=False)
+class AngularIRF:
+    """Response of a 2D angularly-resolved detector: separable blur in wavelength and angle.
+
+    ``eq=False`` because ``ang_axis`` is an array, and elementwise comparison would make
+    a generated ``__eq__`` raise rather than return a bool.
+
+    Args:
+        spect_stddev: Gaussian spectral IRF standard deviation, in nm.
+        ang_stddev: Gaussian angular IRF standard deviation, in degrees.
+        ang_axis: Calibrated angular axis of the detector, in degrees.
+        normalize: Normalization mode, as for :class:`SpectrometerIRF`.
+    """
+
+    spect_stddev: float
+    ang_stddev: float
+    ang_axis: np.ndarray
+    normalize: int
+
+
+def add_ATS_IRF(irf: AngularIRF, lamAxisE, modlE, TSins) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """
     Applies a 2D Gaussian smoothing to angular Thomson scattering data to account for the instrument response function (IRF) of the diagnostic.
-    This function convolves the synthetic spectra with Gaussian kernels along both the wavelength and angular axes, simulating the broadening effects introduced by the instrument. The resulting spectrum is optionally normalized according to configuration parameters.
-    Args:   
-        config (dict): Configuration dictionary containing instrument and normalization parameters.
-        sas (dict): Dictionary with keys 'sa' (scattering angles in degrees) and 'weights' (normalized relative weights for each angle).
+    This function convolves the synthetic spectra with Gaussian kernels along both the wavelength and angular axes, simulating the broadening effects introduced by the instrument. The resulting spectrum is optionally normalized according to the IRF description.
+    Args:
+        irf (AngularIRF): Description of the angular detector's response.
         lamAxisE (jnp.ndarray): Array of wavelengths (in nm) at which the spectrum is computed.
         modlE (jnp.ndarray): Synthetic spectra produced by the formfactor routine, shape (n_angles, n_wavelengths).
-        amps (float): Maximum amplitude of the data, used to rescale the model to the data.
         TSins (dict): Dictionary of Thomson scattering instrument parameters and their values.
     Returns:
         lamAxisE (jnp.ndarray): Wavelength axis (in nm).
         ThryE (jnp.ndarray): Smoothed and optionally normalized synthetic spectra, shape (n_angles, n_wavelengths).
-    """    
+    """
 
-    stddev_lam = config["other"]["PhysParams"]["widIRF"]["spect_FWHM_ele"] / 2.3548
-    stddev_ang = config["other"]["PhysParams"]["widIRF"]["ang_FWHM_ele"] / 2.3548
+    stddev_lam = irf.spect_stddev
+    stddev_ang = irf.ang_stddev
     # Conceptual_origin so the convolution donsn't shift the signal
     origin_lam = (jnp.amax(lamAxisE) + jnp.amin(lamAxisE)) / 2.0
-    origin_ang = (jnp.amax(sas["angAxis"]) + jnp.amin(sas["angAxis"])) / 2.0
+    origin_ang = (jnp.amax(irf.ang_axis) + jnp.amin(irf.ang_axis)) / 2.0
     inst_func_lam = jnp.squeeze(
         (1.0 / (stddev_lam * jnp.sqrt(2.0 * jnp.pi)))
         * jnp.exp(-((lamAxisE - origin_lam) ** 2.0) / (2.0 * (stddev_lam) ** 2.0))
     )  # Gaussian
     inst_func_ang = jnp.squeeze(
         (1.0 / (stddev_ang * jnp.sqrt(2.0 * jnp.pi)))
-        * jnp.exp(-((sas["angAxis"] - origin_ang) ** 2.0) / (2.0 * (stddev_ang) ** 2.0))
+        * jnp.exp(-((irf.ang_axis - origin_ang) ** 2.0) / (2.0 * (stddev_ang) ** 2.0))
     )  # Gaussian
     # Separable 2D convolution: smooth along the angular axis (axis 0) for every
     # wavelength column, then along the wavelength axis (axis 1) for every angle row.
@@ -40,7 +102,7 @@ def add_ATS_IRF(config, sas, lamAxisE, modlE, amps, TSins) -> Tuple[jnp.ndarray,
 
     ThryE = jnp.amax(modlE, axis=1, keepdims=True) / jnp.amax(ThryE, axis=1, keepdims=True) * ThryE
 
-    if config["other"]["PhysParams"]["norm"] > 0:
+    if irf.normalize > 0:
         ThryE = jnp.where(
             lamAxisE < TSins["general"]["lam"],
             TSins["general"]["amp1"] * (ThryE / jnp.amax(ThryE[lamAxisE < TSins["general"]["lam"]])),
@@ -49,12 +111,11 @@ def add_ATS_IRF(config, sas, lamAxisE, modlE, amps, TSins) -> Tuple[jnp.ndarray,
     return lamAxisE, ThryE
 
 
-def add_ion_IRF(config, lamAxisI, modlI, amps, TSins) -> Tuple[jnp.ndarray, jnp.ndarray]:
+def add_ion_IRF(irf: SpectrometerIRF, lamAxisI, modlI, amps, TSins) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """
     Applies an instrumental response function (IRF) to the ion spectral model and optionally normalizes the result.
     Parameters:
-        config (dict): Configuration dictionary containing physical parameters, including the standard deviation
-            of the Gaussian IRF ('spect_stddev_ion') and normalization flag ('norm').
+        irf (SpectrometerIRF): Description of the ion spectrometer's response.
         lamAxisI (jnp.ndarray): Wavelength axis for the ion spectrum.
         modlI (jnp.ndarray): Theoretical ion spectrum model to which the IRF will be applied.
         amps (float or jnp.ndarray): Amplitude scaling factor(s) for the spectrum.
@@ -64,7 +125,7 @@ def add_ion_IRF(config, lamAxisI, modlI, amps, TSins) -> Tuple[jnp.ndarray, jnp.
         ThryI (jnp.ndarray): The processed ion spectrum after convolution with the IRF and optional normalization.
     """
 
-    stddevI = config["other"]["PhysParams"]["widIRF"]["spect_stddev_ion"]
+    stddevI = irf.spect_stddev
     if stddevI:
         originI = (jnp.amax(lamAxisI) + jnp.amin(lamAxisI)) / 2.0
         inst_funcI = jnp.squeeze(
@@ -73,15 +134,15 @@ def add_ion_IRF(config, lamAxisI, modlI, amps, TSins) -> Tuple[jnp.ndarray, jnp.
         )  # Gaussian
         ThryI = jnp.convolve(modlI, inst_funcI, "same")
         ThryI = (jnp.amax(modlI) / jnp.amax(ThryI)) * ThryI
-        ThryI = jnp.average(ThryI.reshape(1024, -1), axis=1)
+        ThryI = jnp.average(ThryI.reshape(irf.n_spectral_pixels, -1), axis=1)
         #print(f"modlI max {jnp.max(modlI)}")
         #print(f"ThryI max {jnp.max(ThryI)}")
         #print(f"amps max {jnp.max(amps)}")
 
-        if config["other"]["PhysParams"]["norm"] == 0:
-            lamAxisI = jnp.average(lamAxisI.reshape(1024, -1), axis=1)
+        if irf.normalize == 0:
+            lamAxisI = jnp.average(lamAxisI.reshape(irf.n_spectral_pixels, -1), axis=1)
             ThryI = TSins["general"]["amp3"] * amps * ThryI / jnp.amax(ThryI)
-            # lamAxisE = jnp.average(lamAxisE.reshape(1024, -1), axis=1)
+            # lamAxisE = jnp.average(lamAxisE.reshape(irf.n_spectral_pixels, -1), axis=1)
     else:
         ThryI = modlI
 
@@ -89,14 +150,14 @@ def add_ion_IRF(config, lamAxisI, modlI, amps, TSins) -> Tuple[jnp.ndarray, jnp.
     return lamAxisI, ThryI
 
 
-def add_electron_IRF(config, lamAxisE, modlE, amps, TSins) -> Tuple[jnp.ndarray, jnp.ndarray]:
+def add_electron_IRF(irf: SpectrometerIRF, lamAxisE, modlE, amps, TSins) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """
     Applies an instrumental response function (IRF) to an electron model spectrum and normalizes the result.
-    This function convolves the input electron model spectrum (`modlE`) with a Gaussian IRF defined by the configuration,
-    normalizes the convolved spectrum according to the provided configuration and signal parameters, and optionally
-    averages and rescales the output based on normalization settings.
+    This function convolves the input electron model spectrum (`modlE`) with a Gaussian IRF defined by the IRF
+    description, normalizes the convolved spectrum according to that description and the signal parameters, and
+    optionally averages and rescales the output based on normalization settings.
     Args:
-        config (dict): Configuration dictionary containing physical parameters, including the IRF width and normalization settings.
+        irf (SpectrometerIRF): Description of the electron spectrometer's response.
         lamAxisE (jnp.ndarray): Wavelength axis for the electron spectrum.
         modlE (jnp.ndarray): Model electron spectrum to which the IRF will be applied.
         amps (float or jnp.ndarray): Amplitude scaling factor(s) for the output spectrum.
@@ -107,7 +168,7 @@ def add_electron_IRF(config, lamAxisE, modlE, amps, TSins) -> Tuple[jnp.ndarray,
         Tuple[jnp.ndarray, jnp.ndarray]: Tuple containing the (possibly averaged) wavelength axis and the processed, normalized electron spectrum.
     """
 
-    stddevE = config["other"]["PhysParams"]["widIRF"]["spect_stddev_ele"]
+    stddevE = irf.spect_stddev
     # Conceptual_origin so the convolution doesn't shift the signal
     originE = (jnp.amax(lamAxisE) + jnp.amin(lamAxisE)) / 2.0
     inst_funcE = jnp.squeeze(
@@ -116,16 +177,16 @@ def add_electron_IRF(config, lamAxisE, modlE, amps, TSins) -> Tuple[jnp.ndarray,
     ThryE = jnp.convolve(modlE, inst_funcE, "same")
     ThryE = (jnp.amax(modlE) / jnp.amax(ThryE)) * ThryE
 
-    if config["other"]["PhysParams"]["norm"] > 0:
+    if irf.normalize > 0:
         ThryE = jnp.where(
             lamAxisE < TSins["general"]["lam"],
             TSins["general"]["amp1"] * (ThryE / jnp.amax(ThryE[lamAxisE < TSins["general"]["lam"]])),
             TSins["general"]["amp2"] * (ThryE / jnp.amax(ThryE[lamAxisE > TSins["general"]["lam"]])),
         )
 
-    ThryE = jnp.average(ThryE.reshape(1024, -1), axis=1)
-    if config["other"]["PhysParams"]["norm"] == 0:
-        lamAxisE = jnp.average(lamAxisE.reshape(1024, -1), axis=1)
+    ThryE = jnp.average(ThryE.reshape(irf.n_spectral_pixels, -1), axis=1)
+    if irf.normalize == 0:
+        lamAxisE = jnp.average(lamAxisE.reshape(irf.n_spectral_pixels, -1), axis=1)
         ThryE = amps * ThryE / jnp.amax(ThryE)
         ThryE = jnp.where(
             lamAxisE < TSins["general"]["lam"], TSins["general"]["amp1"] * ThryE, TSins["general"]["amp2"] * ThryE

--- a/tsadar/core/thomson_diagnostic.py
+++ b/tsadar/core/thomson_diagnostic.py
@@ -2,8 +2,9 @@ from jax import numpy as jnp, vmap
 from scipy.signal import find_peaks
 
 
+from .instrument import irf
+from .instrument import AngularIRF, SpectrometerIRF
 from .modules.ts_params import ThomsonParams
-from .physics import irf
 from .physics.generate_spectra import FitModel
 
 
@@ -29,6 +30,65 @@ def _bin_average(arr, step, axis):
     return jnp.moveaxis(arr, 0, axis)
 
 
+def _irfs_from_config(cfg, scattering_angles):
+    """Adapter from the input deck to device-agnostic IRF descriptions.
+
+    This is the only place that knows how instrument-response settings are laid out in
+    the deck; ``irf.py`` sees only the value objects. When a per-device factory is
+    introduced this function moves there unchanged.
+
+    Returns:
+        (ele_irf, ion_irf, ats_irf): each either its value object or ``None`` if that
+        channel is not in use. Built under exactly the conditions in which
+        ``postprocess_theory`` calls the corresponding routine, so a channel that is
+        never used is never described.
+    """
+
+    widths = cfg["other"]["PhysParams"]["widIRF"]
+    normalize = cfg["other"]["PhysParams"]["norm"]
+    spectype = cfg["other"]["extraoptions"]["spectype"]
+
+    # The IRF-convolved spectrum is computed on a fine grid of `npts` points and then
+    # averaged down onto the detector's wavelength pixels. That pixel count is the length
+    # of the calibrated wavelength axis, which is CCDsize[0] (see
+    # calibration.get_calibrations) -- not the 1024 this code used to hardcode. The two
+    # agree only because OMEGA's CCD is square.
+    n_spectral_pixels = int(cfg["other"]["CCDsize"][0])
+    npts = int(cfg["other"]["npts"])
+
+    def _spectrometer_irf(channel, stddev):
+        if npts % n_spectral_pixels:
+            raise ValueError(
+                f"Cannot bin the {channel} spectrum onto the detector: npts={npts} is not a "
+                f"multiple of n_spectral_pixels={n_spectral_pixels}. npts is derived from "
+                f"CCDsize[1] * points_per_pixel, but the wavelength axis has CCDsize[0] "
+                f"pixels, so this fails for a non-square CCD."
+            )
+        return SpectrometerIRF(
+            spect_stddev=stddev, n_spectral_pixels=n_spectral_pixels, normalize=normalize
+        )
+
+    ele_irf = ion_irf = ats_irf = None
+
+    if cfg["data"]["load_ion_spec"]:
+        ion_irf = _spectrometer_irf("ion", widths["spect_stddev_ion"])
+
+    if cfg["data"]["load_ele_spec"]:
+        if spectype == "angular_full":
+            # The deck stores these as FWHM while the 1D channels store a standard
+            # deviation; normalizing that inconsistency is the adapter's job.
+            ats_irf = AngularIRF(
+                spect_stddev=widths["spect_FWHM_ele"] / 2.3548,
+                ang_stddev=widths["ang_FWHM_ele"] / 2.3548,
+                ang_axis=scattering_angles["angAxis"],
+                normalize=normalize,
+            )
+        else:
+            ele_irf = _spectrometer_irf("electron", widths["spect_stddev_ele"])
+
+    return ele_irf, ion_irf, ats_irf
+
+
 class ThomsonScatteringDiagnostic:
     """
     The SpectrumCalculator class wraps the FitModel class adding instrumental effects to the calculated spectrum so it
@@ -48,6 +108,7 @@ class ThomsonScatteringDiagnostic:
         self.cfg = cfg
         self.scattering_angles = scattering_angles
         self.model = FitModel(cfg, scattering_angles)
+        self.ele_irf, self.ion_irf, self.ats_irf = _irfs_from_config(cfg, scattering_angles)
 
         if ("angular" in cfg["other"]["extraoptions"]["spectype"] 
             or "_interactive" in cfg["other"]["extraoptions"]["spectype"]):
@@ -82,17 +143,15 @@ class ThomsonScatteringDiagnostic:
 
         """
         if self.cfg["data"]["load_ion_spec"]:
-            lamAxisI, ThryI = irf.add_ion_IRF(self.cfg, lamAxisI, modlI, amps["i_amps"], TSins)
+            lamAxisI, ThryI = irf.add_ion_IRF(self.ion_irf, lamAxisI, modlI, amps["i_amps"], TSins)
         else:
             ThryI = modlI
 
         if self.cfg["data"]["load_ele_spec"]:
             if self.cfg["other"]["extraoptions"]["spectype"] == "angular_full":
-                lamAxisE, ThryE = irf.add_ATS_IRF(
-                    self.cfg, self.scattering_angles, lamAxisE, modlE, amps["e_amps"], TSins
-                )
+                lamAxisE, ThryE = irf.add_ATS_IRF(self.ats_irf, lamAxisE, modlE, TSins)
             else:
-                lamAxisE, ThryE = irf.add_electron_IRF(self.cfg, lamAxisE, modlE, amps["e_amps"], TSins)
+                lamAxisE, ThryE = irf.add_electron_IRF(self.ele_irf, lamAxisE, modlE, amps["e_amps"], TSins)
         else:
             ThryE = modlE
 


### PR DESCRIPTION
Toward #105. Independent of #106/#107 — no file overlap; rebases cleanly either way.

irf.py contained no physics -- three Gaussian convolutions, a pixel binning,
and an amplitude normalization, all driven by device parameters. Move it to a
new core/instrument/ package and make it config-free.

- Add SpectrometerIRF / AngularIRF frozen dataclasses describing the detector.
  All fields required; no defaults, and no from_config, so the dependency runs
  adapter -> value object and never back.
- Replace three hardcoded reshape(1024, -1) with n_spectral_pixels. The correct
  value is CCDsize[0], the length of the calibrated wavelength axis; 1024 only
  worked because OMEGA's CCD is square.
- Add _irfs_from_config in ThomsonScatteringDiagnostic as the single adapter
  from input deck to value objects, so cfg stops at the constructor. It also
  normalizes the deck's FWHM-vs-stddev inconsistency between the ATS and 1D
  channels, and raises on a non-square CCD instead of silently mis-binning.
- Drop the unused amps and sas arguments from add_ATS_IRF.

 #105's target layering places irf in the "synthetic diagnostic" layer rather than under physics. This does that move, and makes the file honest while it's in flight: irf.py had no physics in it, only device-driven convolutions plus a hardcoded 1024 CCD dimension. Where #107 isolates the source of diagnostic specifics (a data provider supplying sa, calibrations), this isolates their consumption — what the model code receives, and in what shape.

