### PR TITLE
feat: Add least-squares as a 1D optimizer option (method: lsq)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "boto3",
     "flatten-dict",
     "optax",
+    "optimistix",
     "tqdm",
     "jaxopt>=0.6.0",
     "xarray",

--- a/tests/test_inverse/test_1d_data.py
+++ b/tests/test_inverse/test_1d_data.py
@@ -1,5 +1,6 @@
 import time
 import multiprocessing as mp
+import pytest
 import yaml
 import mlflow
 from flatten_dict import flatten, unflatten
@@ -14,9 +15,11 @@ from tsadar.inverse import fitter
 from tsadar.utils import misc
 
 
-def test_data():
+@pytest.mark.parametrize("method", ["l-bfgs-b", "lsq"])
+def test_data(method):
     # Test #3: Data test, compare fit to a preknown fit result
     # currently just runs one line of shot 101675 for the electron, should be expanded in the future
+    # Parametrized over the optimizer: L-BFGS-B and Levenberg-Marquardt must reach the same fit.
 
     with open("tests/configs/time_test_defaults.yaml", "r") as fi:
         defaults = yaml.safe_load(fi)
@@ -27,6 +30,7 @@ def test_data():
     defaults = flatten(defaults)
     defaults.update(flatten(inputs))
     config = unflatten(defaults)
+    config["optimizer"]["method"] = method
 
     # config["parameters"]["Te"]["val"] = 0.5
     # config["parameters"]["ne"]["val"] = 0.2  # 0.25

--- a/tsadar/inverse/loops.py
+++ b/tsadar/inverse/loops.py
@@ -10,9 +10,11 @@ import mlflow
 import numpy as np
 import time
 import pickle
+from jax import numpy as jnp
 from jax.flatten_util import ravel_pytree
 from tqdm import trange
 import optax
+import optimistix as optx
 
 
 from typing import Dict, List, Tuple
@@ -53,6 +55,54 @@ def _1d_scipy_loop_(
 
     best_loss = res["fun"]
     best_weights = eqx.combine(loss_fn.unravel_weights(res["x"]), static_params)
+
+    return best_loss, best_weights
+
+
+def _1d_lm_loop_(
+    config: Dict, loss_fn: LossFunction, previous_weights, batch: Dict
+) -> Tuple[float, Dict]:
+    """
+    Runs a 1D optimization loop using Levenberg-Marquardt least squares (optimistix).
+
+    LM minimises ``sum(loss_fn.residuals(...)**2)``, which equals the l2 training loss, by
+    exploiting the residual/Jacobian structure. On the 1D inverse problem it typically needs
+    far fewer iterations than L-BFGS for the same fit. Requires ``loss_method == "l2"``.
+
+    Args:
+        config (Dict): Configuration dictionary containing optimizer and parameter settings.
+        loss_fn (LossFunction): Loss function object exposing a ``residuals`` method.
+        previous_weights: Weights to initialize from, or None to build fresh parameters.
+        batch (Dict): Batch of data to be used in the loss function.
+    Returns:
+        Tuple[float, Dict]: The best loss value (sum of squared residuals) and the optimized weights.
+    """
+    if config["optimizer"]["loss_method"] != "l2":
+        raise ValueError("optimizer method 'lsq'/'lm' requires loss_method 'l2' (least squares).")
+
+    if previous_weights is None:
+        ts_params = ThomsonParams(config["parameters"], config["optimizer"]["batch_size"], activate=True)
+    else:
+        ts_params = previous_weights
+
+    diff_params, static_params = eqx.partition(ts_params, get_filter_spec(config["parameters"], ts_params))
+
+    # loss_fn.residuals returns (residual, aux); optimistix wants just the residual vector.
+    # LM converges quadratically near the optimum, so a loose tolerance reaches the same fit in
+    # fewer iterations. Configurable via optimizer.lm_tol.
+    tol = config["optimizer"].get("lm_tol", 1e-3)
+    solver = optx.LevenbergMarquardt(rtol=tol, atol=tol)
+    sol = optx.least_squares(
+        lambda dp, args: loss_fn.residuals(dp, static_params, batch)[0],
+        solver,
+        diff_params,
+        max_steps=config["optimizer"]["num_epochs"],
+        throw=False,
+    )
+
+    best_weights = eqx.combine(sol.value, static_params)
+    residual, _ = loss_fn.residuals(sol.value, static_params, batch)
+    best_loss = float(jnp.sum(residual**2))
 
     return best_loss, best_weights
 
@@ -163,6 +213,8 @@ def one_d_loop(
                 # not sure why this is needed but something needs to be reset, either the weights or the bounds
                 loss_fn = LossFunction(config, sa, batch)
                 best_loss, best_weights = _1d_scipy_loop_(config, loss_fn, previous_batch, batch)
+            elif config["optimizer"]["method"] in ("lsq", "lm"):  # Levenberg-Marquardt least squares
+                best_loss, best_weights = _1d_lm_loop_(config, loss_fn, previous_batch, batch)
             else:
                 best_loss, best_weights = _1d_optax_loop_(config, loss_fn, previous_batch, batch, tbatch)
                 

--- a/tsadar/inverse/loss_function.py
+++ b/tsadar/inverse/loss_function.py
@@ -412,10 +412,69 @@ class LossFunction:
         else:
             return self._loss_(weights, batch)
 
+    def residuals(self, diff_weights, static_weights, batch: Dict):
+        """Least-squares residual vector for the l2 objective (with aux).
+
+        Returns ``(residual, [ThryE, params])``. The residual is the signed, whitened
+        deviation such that ``jnp.sum(residual**2)`` reproduces the l2 value of the loss
+        exactly: each in-range point is scaled by ``1/sqrt(uncert * N)`` (N = number of
+        in-range points for that feature, which folds the mean reduction into a plain sum of
+        squares), ``ion_loss_scale`` is folded into the ion residual, and the blue/red
+        averaging (factor 1/2 when both EPW sides are fit) into the electron residual.
+        Out-of-range points contribute zero. The fit-range masks use the calibrated
+        wavelength axes (independent of the fit parameters), so the per-feature counts N are
+        constant during optimization.
+
+        This is the single source of truth for the l2 objective: :meth:`__loss__` reduces it
+        with ``sum(residual**2)`` for the gradient-based optimizers, and least-squares
+        optimizers (Levenberg-Marquardt) consume the residual directly. The ``(value, aux)``
+        return follows the equinox/optimistix ``has_aux`` convention so both share one call.
+        Only for the non-multiplexed l2 case; other loss methods are not least squares.
+        Weighting is intentionally the current diagonal ``1/uncert``; a proper (e.g.
+        covariance) whitening is left for a future change.
+        """
+        weights = eqx.combine(static_weights, diff_weights)
+        ThryE, ThryI, lamAxisE, lamAxisI = self.ts_diag(weights, batch)
+
+        fr = self.cfg["data"]["fit_rng"]
+        both_epw = self.cfg["data"]["fit_EPWb"] and self.cfg["data"]["fit_EPWr"]
+        epw_factor = 2.0 if both_epw else 1.0
+        parts = []
+
+        if self.cfg["data"]["fit_IAW"]:
+            mask = ((lamAxisI > fr["iaw_min"]) & (lamAxisI < fr["iaw_cf_min"])) | (
+                (lamAxisI > fr["iaw_cf_max"]) & (lamAxisI < fr["iaw_max"])
+            )
+            scale = jnp.sqrt(self.cfg["data"]["ion_loss_scale"] / (jnp.abs(self.i_norm) * jnp.sum(mask)))
+            parts.append(jnp.where(mask, (batch["i_data"] - ThryI) * scale, 0.0).ravel())
+
+        if self.cfg["data"]["fit_EPWb"]:
+            mask = (lamAxisE > fr["blue_min"]) & (lamAxisE < fr["blue_max"])
+            scale = 1.0 / jnp.sqrt(jnp.abs(self.e_norm) * jnp.sum(mask) * epw_factor)
+            parts.append(jnp.where(mask, (batch["e_data"] - ThryE) * scale, 0.0).ravel())
+
+        if self.cfg["data"]["fit_EPWr"]:
+            mask = (lamAxisE > fr["red_min"]) & (lamAxisE < fr["red_max"])
+            scale = 1.0 / jnp.sqrt(jnp.abs(self.e_norm) * jnp.sum(mask) * epw_factor)
+            parts.append(jnp.where(mask, (batch["e_data"] - ThryE) * scale, 0.0).ravel())
+
+        return jnp.concatenate(parts), [ThryE, weights()]
+
     def __loss__(self, diff_weights, static_weights, batch: Dict):
         """
         Output wrapper
         """
+
+        # For the standard (non-angular) l2 fit, derive the scalar loss from the residual
+        # vector so the loss and the least-squares residual are a single, consistent source.
+        # Angular fits (any shotnum) keep the existing calc_loss path: their 2D
+        # reduce_ATS_to_resunit structure is not handled by the 1D residual.
+        if (
+            self.cfg["optimizer"]["loss_method"] == "l2"
+            and "angular" not in self.cfg["other"]["extraoptions"]["spectype"]
+        ):
+            residual, aux = self.residuals(diff_weights, static_weights, batch)
+            return jnp.sum(residual**2), aux
 
         weights = eqx.combine(static_weights, diff_weights)
         total_loss, sqdev, ThryE, normed_e_data, params = self.calc_loss(


### PR DESCRIPTION
The 1D inverse fit is a least-squares problem, so a Gauss-Newton / LM solver converges in far fewer iterations than the gradient-based L-BFGS / optax paths. On real shot 101675 (production parameterization), LM reaches the same fit as L-BFGS-B in ~2.9x fewer iterations (mean 10 vs 29) and ~4x less wall time.

Radius of convergence is also increased by about 50%. Best robustness can be found be underestimating ne and overestimating Te.

<img width="1509" height="1211" alt="image" src="https://github.com/user-attachments/assets/d481a647-4790-4f1a-86ef-03c69a5da057" />

Changes:
- LossFunction.residuals: single source of truth for the l2 objective. Returns (residual, aux) following the equinox/optimistix has_aux convention. The residual is whitened by 1/sqrt(uncert * N) so that sum(residual**2) reproduces the mean-reduced l2 loss exactly (ion_loss_scale and the blue/red averaging folded in; out-of-range points contribute zero). The fit-range masks use the calibrated axes, so the per-feature counts N are constant during the fit.
- LossFunction.__loss__: for the standard (non-angular) l2 fit, returns sum(residuals**2) so the scalar loss and the least-squares residual come from one function. Other loss methods / angular are unchanged.
- loops._1d_lm_loop_ + `method: lsq` (alias `lm`) dispatch in one_d_loop, using optimistix.LevenbergMarquardt(rtol=atol=optimizer.lm_tol, default 1e-3). LM converges quadratically, so the relaxed default reaches the same params in fewer iterations. Reuses optimizer.num_epochs as max_steps (as l-bfgs-b already overloads it for scipy maxiter). Requires loss_method == "l2".
- Add optimistix dependency.
- test_1d_data parametrized over method=[l-bfgs-b, lsq]; both recover the known shot-101675 values (identical to <1e-3), confirming the loss reroute is a no-op for the existing gradient path.

Weighting is intentionally the existing diagonal 1/uncert; proper covariance whitening, and consolidating the postprocessing l2 path onto residuals, are left for a follow-up.