### PR TITLE
Bremsstrahlung background

### DIFF
--- a/tsadar/data/correct_throughput.py
+++ b/tsadar/data/correct_throughput.py
@@ -1,6 +1,5 @@
 import xlrd
 import numpy as np
-from numpy.matlib import repmat
 import scipy.interpolate as sp
 import scipy.io as sio
 from os.path import join
@@ -80,7 +79,7 @@ def correctThroughput(data, tstype, axisy, shotNum):
         vq1 = speccalshift(axisy)
 
     # Note that C has NaN in it.
-    C = np.transpose(repmat(vq1, 1024, 1))  # expand my wavelength corrections vector into a matrix
+    C = np.transpose(np.tile(vq1, (1024, 1)))  # expand my wavelength corrections vector into a matrix
     C[np.isnan(C)] = 0
     cdata = data * C
     # Correct each wavelength/Row of the matrix

--- a/tsadar/data/data_visualizer.py
+++ b/tsadar/data/data_visualizer.py
@@ -138,7 +138,7 @@ def launch_data_visualizer(elecData, ionData, all_data, all_axes, config):
             
 
         # Plot lineout of the data with its background to check background subtraction
-        if config["data"]["background"]["type"].casefold() in ["fit", "pixel"]:
+        if config["data"]["background"]["report_background"]:
             #create a figure with 6 subplots, 3 for the electron lineouts and 3 for the ion lineouts, with the lineouts and the backgrounds plotted together
             num_lineouts = len(all_data["e_data"]) if all_data["e_data"].size > 0 else len(all_data["i_data"])
             lineout_indices = [0, num_lineouts // 2, num_lineouts - 1]

--- a/tsadar/data/evaluate_background.py
+++ b/tsadar/data/evaluate_background.py
@@ -10,6 +10,11 @@ from .load_ts_data import loadData
 from .correct_throughput import correctThroughput
 
 
+def is_bremsstrahlung_bg_type(bg_type: str) -> bool:
+    """Matches 'bremsstrahlung' and shortened aliases such as 'brem' or 'bremstrahlung'."""
+    return bg_type.casefold().startswith("brem")
+
+
 def get_shot_bg(config, shotNum, axisyE, elecData):
     """
     Computes the background electron and ion spectra for a given shot based on data from another shot.
@@ -84,7 +89,7 @@ def get_shot_bg(config, shotNum, axisyE, elecData):
 
 
 def get_lineout_bg(
-    config, elecData, ionData, BGele, BGion, LineoutTSE_smooth, BackgroundPixel, LineoutPixelE, LineoutPixelI
+    config, elecData, ionData, BGele, BGion, LineoutTSE_smooth, BackgroundPixel, LineoutPixelE, LineoutPixelI, axisyE, axisyI
 ) -> Tuple[np.ndarray, np.ndarray]:
     """
     This function generates noise or background profiles to based off the data or background data.
@@ -115,8 +120,8 @@ def get_lineout_bg(
     span = 2 * config["data"]["dpixel"] + 1  # (span must be odd)
 
     # Check if the background type is valid
-    if config["data"]["background"]["type"].casefold() not in ["fit", "shot", "pixel"]:
-        raise NotImplementedError("Background type must be: 'Fit', 'Shot', or 'Pixel'")
+    if config["data"]["background"]["type"].casefold() not in ["fit", "shot", "pixel","brem","bremsstrahlung"]:
+        raise NotImplementedError("Background type must be: 'Fit', 'Shot', 'Pixel', or 'Bremsstrahlung'")
 
     # for electrons, if the background type is "fit" and the data type is not "angular"
     if config["data"]["load_ele_spec"]:
@@ -158,6 +163,15 @@ def get_lineout_bg(
 
                     LineoutBGE.append(bgalg(np.arange(1024), *pvec))
         # if not fit use a pixel lineout with smoothing
+        elif config["data"]["background"]["type"].casefold() in ["brem","bremsstrahlung"]:
+            # fit a bremsstrahlung model to the edges of the lineout
+            brem = lambda x, a, c, Z, Te, ne: 10**8 *Z * ne**2 / Te**0.5 / x**2* np.exp(4.1357*10**-15 *2.99792*10**10 / (x * Te)) * a + c
+            LineoutBGE = []
+            for i, _ in enumerate(config["data"]["lineouts"]["val"]):
+                [pvec, _] = spopt.curve_fit(brem,axisyE[bgfitx], LineoutTSE_smooth[i][bgfitx], [config["data"]["background"]["bg_alg_params"][0],config["data"]["background"]["bg_alg_params"][1], config['parameters']['ion-1']['Z']['val'], config['parameters']['electron']['Te']['val'], config['parameters']['electron']['ne']['val']])
+
+                LineoutBGE.append(brem(axisyE, *pvec))
+
         else:
             # quantify a background lineout
             LineoutBGE = np.mean(

--- a/tsadar/data/lineouts.py
+++ b/tsadar/data/lineouts.py
@@ -96,7 +96,7 @@ def get_lineouts(
         BackgroundPixel = LineoutPixelE + 100
     elif config["data"]["background"]["type"].casefold() == "shot":
         BackgroundPixel = 900
-    elif config["data"]["background"]["type"].casefold() == "fit":
+    elif config["data"]["background"]["type"].casefold() in ["fit", "brem", "bremsstrahlung"]:
         BackgroundPixel = config["data"]["background"]["slice"]
     else:
         BackgroundPixel = []
@@ -137,7 +137,7 @@ def get_lineouts(
 
     # Find background signal combining information from a background shot and background lineout
     [noiseE, noiseI] = get_lineout_bg(
-        config, elecData, ionData, BGele, BGion, LineoutTSE_smooth, BackgroundPixel, LineoutPixelE, LineoutPixelI
+        config, elecData, ionData, BGele, BGion, LineoutTSE_smooth, BackgroundPixel, LineoutPixelE, LineoutPixelI, axisyE, axisyI,
     )
 
     # Find data amplitudes


### PR DESCRIPTION
Adds a brem model as a new option for background algorithms. This model uses the initial plasma conditions as guesses to fit the brem model to the edges of the data. Also fixes repmat depreciation. Stacked on bugfix/gradients.