### PR TITLE
Refactor postprocessor to be optional 

### DIFF
--- a/tests/test_inverse/test_refit.py
+++ b/tests/test_inverse/test_refit.py
@@ -1,0 +1,62 @@
+import time
+import multiprocessing as mp
+import yaml
+import mlflow
+from flatten_dict import flatten, unflatten
+from numpy.testing import assert_allclose
+from jax import config
+
+config.update("jax_enable_x64", True)
+
+from tsadar.inverse import fitter
+from tsadar.utils import misc
+
+
+def test_refit():
+    # Regression test for the refit_bad_fits path (postprocess.py), which is otherwise never exercised by
+    # the other inverse tests since they all run with other.refit = false. Forces every lineout to be flagged
+    # as "bad" so refit_bad_fits actually attempts a refit, guarding against the pytree-structure mismatch
+    # that used to crash this path (fitted_weights[idx] wasn't dict-subscriptable, and the "m" override was
+    # nested one level too shallow relative to the fe.params.m config schema).
+    #
+    # This config has 2 lineouts (lineouts.start=500, end=510, skip=5) with batch_size=2, which matters because
+    # refit_bad_fits hardcodes `if i == 0: continue`, i.e. the first lineout in the batch can never be refit -
+    # at least 2 lineouts are needed for the refit loop body to actually run.
+    with open("tests/configs/time_test_defaults.yaml", "r") as fi:
+        defaults = yaml.safe_load(fi)
+
+    with open("tests/configs/time_test_inputs.yaml", "r") as fi:
+        inputs = yaml.safe_load(fi)
+
+    defaults = flatten(defaults)
+    defaults.update(flatten(inputs))
+    config = unflatten(defaults)
+
+    config["other"]["refit"] = True
+    config["other"]["refit_thresh"] = -1.0  # losses are non-negative, so this flags every lineout as "bad"
+
+    mlflow.set_experiment("tsadar-tests")
+
+    with mlflow.start_run() as run:
+        misc.log_mlflow(config)
+        config["num_cores"] = int(mp.cpu_count())
+
+        t0 = time.time()
+        fit_results, loss = fitter.fit(config=config)
+        metrics_dict = {"total_time": time.time() - t0, "num_cores": int(mp.cpu_count())}
+        mlflow.log_metrics(metrics=metrics_dict)
+        mlflow.set_tag("status", "completed")
+        print(fit_results)
+
+        # loose sanity bounds (not tight regression values like test_1d_data.py) - the point of this test is
+        # that fitter.fit() completes without raising when refit is forced on, and still returns physically
+        # reasonable parameters for both lineouts, not that refit reproduces a specific known-good fit.
+        assert len(fit_results["Te_electron"]) == 2
+        for i in range(2):
+            assert 0.0 < fit_results["Te_electron"][i] < 5.0
+            assert 0.0 < fit_results["ne_electron"][i] < 1.0
+            assert 0.0 < fit_results["m_electron"][i] < 10.0
+
+
+if __name__ == "__main__":
+    test_refit()

--- a/tsadar/data/evaluate_background.py
+++ b/tsadar/data/evaluate_background.py
@@ -9,12 +9,6 @@ from scipy.signal import convolve2d as conv2
 from .load_ts_data import loadData
 from .correct_throughput import correctThroughput
 
-
-def is_bremsstrahlung_bg_type(bg_type: str) -> bool:
-    """Matches 'bremsstrahlung' and shortened aliases such as 'brem' or 'bremstrahlung'."""
-    return bg_type.casefold().startswith("brem")
-
-
 def get_shot_bg(config, shotNum, axisyE, elecData):
     """
     Computes the background electron and ion spectra for a given shot based on data from another shot.
@@ -165,7 +159,8 @@ def get_lineout_bg(
         # if not fit use a pixel lineout with smoothing
         elif config["data"]["background"]["type"].casefold() in ["brem","bremsstrahlung"]:
             # fit a bremsstrahlung model to the edges of the lineout
-            brem = lambda x, a, c, Z, Te, ne: 10**8 *Z * ne**2 / Te**0.5 / x**2* np.exp(4.1357*10**-15 *2.99792*10**10 / (x * Te)) * a + c
+            brem = lambda x, a, c, Z, Te, ne: 10**8 *Z * ne**2 / Te**0.5 / x**2* np.exp(-1.24 / (x * Te)) * a + c
+            
             LineoutBGE = []
             for i, _ in enumerate(config["data"]["lineouts"]["val"]):
                 [pvec, _] = spopt.curve_fit(brem,axisyE[bgfitx], LineoutTSE_smooth[i][bgfitx], [config["data"]["background"]["bg_alg_params"][0],config["data"]["background"]["bg_alg_params"][1], config['parameters']['ion-1']['Z']['val'], config['parameters']['electron']['Te']['val'], config['parameters']['electron']['ne']['val']])

--- a/tsadar/inverse/calc_vs_data.py
+++ b/tsadar/inverse/calc_vs_data.py
@@ -6,6 +6,7 @@ import yaml
 from ..core.thomson_diagnostic import ThomsonScatteringDiagnostic
 from ..core.modules.ts_params import ThomsonParams
 from .fitter import _validate_inputs_, load_data_for_fitting
+from .loops import build_batch
 from ..data.calibration import get_calibrations
 from .loss_function import LossFunction
 
@@ -188,14 +189,7 @@ def forward_pass(config):
         else:
             sas['sa'] = sas['sa']
             sas['weights'] = sas['weights']
-    batch = {
-                "e_data": all_data["e_data"][0]-all_data["noiseE"][0] if background_subtract else all_data["e_data"][0],
-                "e_amps": all_data["e_amps"][0],
-                "i_data": all_data["i_data"][0]-all_data["noiseI"][0] if background_subtract else all_data["i_data"][0],
-                "i_amps": all_data["i_amps"][0],
-                "noise_e": all_data["noiseE"][0] if not background_subtract else 0.0,
-                "noise_i": all_data["noiseI"][0] if not background_subtract else 0.0,
-            }
+    batch = build_batch(all_data, np.array([0]), background_subtract)
 
     fig = make_subplots(rows=2, cols=2, specs=[[{"secondary_y": False}, {"secondary_y": False}], [{"secondary_y": True}, {"secondary_y": True}]],
                         subplot_titles=("Electron Spectrum", "Ion Spectrum", "Electron Chisq",  "Ion Chisq"))

--- a/tsadar/inverse/fitter.py
+++ b/tsadar/inverse/fitter.py
@@ -1,14 +1,55 @@
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
+import os
+import tempfile
 import time
 import numpy as np
 import pandas as pd
+import equinox as eqx
 
 import mlflow
 
 from tsadar.inverse.loops import multirun_angular_optax, one_d_loop, unbatch_fitted_params
+from tsadar.utils.plotting import plotters
 
 from ..data import prepare
 from . import postprocess
+
+
+def _save_fit_artifacts(config: Dict, all_axes: Dict, fitted_weights, all_params: Optional[Dict]):
+    """
+    Persists the raw fit results to mlflow independently of postprocess, so they survive even if
+    postprocess is skipped (config["other"]["run_postprocess"] = False) or fails partway through.
+
+    Saves two things:
+        - fitted_weights: the live equinox pytree, via eqx.tree_serialise_leaves. This saves only the
+          array leaves (not the lambda-valued activation functions), so restoring it later requires
+          rebuilding a matching "skeleton" ThomsonParams tree from the same config and calling
+          eqx.tree_deserialise_leaves on it - this is the standard equinox checkpointing pattern and is
+          robust to being loaded by a different process/session, unlike pickling the object directly.
+        - all_params: the flattened per-lineout fitted values, as the same CSV artifacts
+          plotters.get_final_params produces during normal postprocessing.
+
+    Args:
+        config (Dict): Configuration dictionary built from the input deck.
+        all_axes (Dict): Calibrated axes and axis labels, needed by plotters.get_final_params.
+        fitted_weights: The fitted weights returned by the minimizer (list of ThomsonParams for 1D fits,
+            a single ThomsonParams for angular fits).
+        all_params (Optional[Dict]): Unbatched fitted parameters from unbatch_fitted_params, or None
+            (angular fits don't compute this at the fitter level).
+    Returns:
+        The dict returned by plotters.get_final_params, or None if all_params wasn't available.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        os.makedirs(os.path.join(td, "csv"), exist_ok=True)
+        eqx.tree_serialise_leaves(os.path.join(td, "fitted_weights.eqx"), fitted_weights)
+
+        final_params = None
+        if all_params is not None:
+            final_params = plotters.get_final_params(config, all_params, all_axes, td)
+
+        mlflow.log_artifacts(td)
+
+    return final_params
 
 
 def _validate_inputs_(config: Dict) -> Dict:
@@ -139,12 +180,24 @@ def fit(config) -> Tuple[pd.DataFrame, float]:
 
     mlflow.log_metrics({"overall loss": float(overall_loss)})
     mlflow.log_metrics({"fit_time": round(time.time() - t1, 2)})
-    mlflow.set_tag("status", "postprocessing")
-    print("postprocessing")
 
-    final_params = postprocess.postprocess(
-        config, sample_indices, all_data, all_axes, loss_fn, sa, fitted_weights, all_params, num_params
-    )
+    saved_final_params = _save_fit_artifacts(config, all_axes, fitted_weights, all_params)
+
+    if config["other"].get("run_postprocess", True):
+        mlflow.set_tag("status", "postprocessing")
+        print("postprocessing")
+
+        final_params = postprocess.postprocess(
+            config, sample_indices, all_data, all_axes, loss_fn, sa, fitted_weights, all_params, num_params
+        )
+    else:
+        if saved_final_params is None:
+            raise NotImplementedError(
+                "run_postprocess=False is currently only supported for non-angular fits, since all_params "
+                "(and therefore final_params) is only computed at the fitter level for the 1D path."
+            )
+        final_params = saved_final_params
+        mlflow.set_tag("status", "done fitting (postprocess skipped)")
 
     return final_params, float(overall_loss)
 

--- a/tsadar/inverse/fitter.py
+++ b/tsadar/inverse/fitter.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 import mlflow
 
-from tsadar.inverse.loops import multirun_angular_optax, one_d_loop
+from tsadar.inverse.loops import multirun_angular_optax, one_d_loop, unbatch_fitted_params
 
 from ..data import prepare
 from . import postprocess
@@ -132,15 +132,19 @@ def fit(config) -> Tuple[pd.DataFrame, float]:
 
     if "angular" in config["other"]["extraoptions"]["spectype"]:
         fitted_weights, overall_loss, loss_fn = multirun_angular_optax(config, all_data, sa)
+        all_params, num_params = None, None
     else:
         fitted_weights, overall_loss, loss_fn = one_d_loop(config, all_data, sa, sample_indices, num_batches)
+        all_params, num_params = unbatch_fitted_params(config, fitted_weights)
 
     mlflow.log_metrics({"overall loss": float(overall_loss)})
     mlflow.log_metrics({"fit_time": round(time.time() - t1, 2)})
     mlflow.set_tag("status", "postprocessing")
     print("postprocessing")
 
-    final_params = postprocess.postprocess(config, sample_indices, all_data, all_axes, loss_fn, sa, fitted_weights)
+    final_params = postprocess.postprocess(
+        config, sample_indices, all_data, all_axes, loss_fn, sa, fitted_weights, all_params, num_params
+    )
 
     return final_params, float(overall_loss)
 

--- a/tsadar/inverse/loops.py
+++ b/tsadar/inverse/loops.py
@@ -1,4 +1,5 @@
 from functools import partial
+from collections import defaultdict
 from tsadar.core.modules.ts_params import ThomsonParams, get_filter_spec
 from optax import tree_utils as otu
 import equinox as eqx
@@ -181,6 +182,32 @@ def one_d_loop(
                     #     previous_weights, _ = ravel_pytree(best_weights)
 
     return all_weights, overall_loss, loss_fn
+
+
+def unbatch_fitted_params(config: Dict, fitted_weights: List) -> Tuple[Dict, int]:
+    """
+    Flattens the per-batch fitted-weight objects returned by `one_d_loop` into a single dict of
+    concatenated parameter arrays.
+
+    Args:
+        config (Dict): Configuration dictionary containing the parameter settings.
+        fitted_weights (List): List of per-batch fitted weight objects, each exposing `get_fitted_params`.
+    Returns:
+        Tuple[Dict, int]: The unbatched parameters and the number of active fitted parameters.
+    """
+    all_params = {k: defaultdict(list) for k in config["parameters"].keys()}
+    num_params = 0
+    for _fw in fitted_weights:
+        batch_fitted_params, num_params = _fw.get_fitted_params(config["parameters"])
+        for k in batch_fitted_params.keys():
+            for k2 in batch_fitted_params[k].keys():
+                all_params[k][k2].append(batch_fitted_params[k][k2])
+
+    for k in all_params.keys():
+        for k2 in all_params[k].keys():
+            all_params[k][k2] = np.concatenate(all_params[k][k2])
+
+    return all_params, num_params
 
 
 def angular_optax(config, sa, loss_fn, actual_data, previous_weights=None, previous_epoch=None):

--- a/tsadar/inverse/loops.py
+++ b/tsadar/inverse/loops.py
@@ -19,6 +19,62 @@ import optax
 from typing import Dict, List, Tuple
 
 
+def build_batch(all_data: Dict, inds, background_subtract: bool) -> Dict:
+    """
+    Slices a batch of lineouts out of `all_data`, optionally subtracting the background noise from the data
+    (leaving the model to add it back in) instead of passing the noise through as a separate fit term.
+
+    Args:
+        all_data (Dict): Dictionary containing all input data arrays required for fitting.
+        inds: Indices (or index array) selecting which lineouts to include in the batch.
+        background_subtract (bool): Whether to subtract noise from the data here rather than fit it separately.
+    Returns:
+        Dict: Batch dictionary with e_data/i_data, amplitudes, and noise terms for the selected indices.
+    """
+    return {
+        "e_data": all_data["e_data"][inds] - all_data["noiseE"][inds] if background_subtract else all_data["e_data"][inds],
+        "e_amps": all_data["e_amps"][inds],
+        "i_data": all_data["i_data"][inds] - all_data["noiseI"][inds] if background_subtract else all_data["i_data"][inds],
+        "i_amps": all_data["i_amps"][inds],
+        "noise_e": all_data["noiseE"][inds] if not background_subtract else 0.0,
+        "noise_i": all_data["noiseI"][inds] if not background_subtract else 0.0,
+    }
+
+
+def build_angular_batch(config: Dict, all_data: Dict) -> Dict:
+    """
+    Builds the angular-data batch (or dict of two batches, for multiplexed/rotated shots) sliced to the
+    configured lineout start:end range. Assumes any unit conversion of the lineout start/end (e.g. by
+    ang_res_unit) has already been applied to `config` by the caller.
+
+    Args:
+        config (Dict): Configuration dictionary containing the lineout start/end and shot settings.
+        all_data (Dict): Dictionary containing all input data arrays required for fitting.
+    Returns:
+        Dict: `batch1` directly for a single shot, or {"b1": batch1, "b2": batch2} for rotated multi-shot data.
+    """
+    start, end = config["data"]["lineouts"]["start"], config["data"]["lineouts"]["end"]
+    batch1 = {
+        "e_data": all_data["e_data"][start:end, :],
+        "e_amps": all_data["e_amps"][start:end, :],
+        "i_data": all_data["i_data"],
+        "i_amps": all_data["i_amps"],
+        "noise_e": all_data["noiseE"][start:end, :],
+        "noise_i": all_data["noiseI"][start:end, :],
+    }
+    if isinstance(config["data"]["shotnum"], list):
+        batch2 = {
+            "e_data": all_data["e_data_rot"][start:end, :],
+            "e_amps": all_data["e_amps_rot"][start:end, :],
+            "noise_e": all_data["noiseE_rot"][start:end, :],
+            "i_data": all_data["i_data"],
+            "i_amps": all_data["i_amps"],
+            "noise_i": all_data["noiseI"][start:end, :],
+        }
+        return {"b1": batch1, "b2": batch2}
+    return batch1
+
+
 def _1d_scipy_loop_(
     config: Dict, loss_fn: LossFunction, previous_weights: np.ndarray, batch: Dict
 ) -> Tuple[float, Dict]:
@@ -151,14 +207,7 @@ def one_d_loop(
         for i_batch in tbatch:
             previous_batch = previous_weights[i_batch] if previous_weights is not None else previous_batch
             inds = batch_indices[i_batch]
-            batch = {
-                "e_data": all_data["e_data"][inds]-all_data["noiseE"][inds] if background_subtract else all_data["e_data"][inds],
-                "e_amps": all_data["e_amps"][inds],
-                "i_data": all_data["i_data"][inds]-all_data["noiseI"][inds] if background_subtract else all_data["i_data"][inds],
-                "i_amps": all_data["i_amps"][inds],
-                "noise_e": all_data["noiseE"][inds] if not background_subtract else 0.0,
-                "noise_i": all_data["noiseI"][inds] if not background_subtract else 0.0,
-            }
+            batch = build_batch(all_data, inds, background_subtract)
 
             if config["optimizer"]["method"] == "l-bfgs-b":  # Stochastic Gradient Descent
                 # not sure why this is needed but something needs to be reset, either the weights or the bounds
@@ -324,32 +373,8 @@ def multirun_angular_optax(
     config["optimizer"]["batch_size"] = 1
     config["data"]["lineouts"]["start"] = int(config["data"]["lineouts"]["start"] / config["other"]["ang_res_unit"])
     config["data"]["lineouts"]["end"] = int(config["data"]["lineouts"]["end"] / config["other"]["ang_res_unit"])
-    batch1 = {
-        "e_data": all_data["e_data"][config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :],
-        "e_amps": all_data["e_amps"][config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :],
-        "i_data": all_data["i_data"],
-        "i_amps": all_data["i_amps"],
-        "noise_e": all_data["noiseE"][config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :],
-        "noise_i": all_data["noiseI"][config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :],
-    }
-    if isinstance(config["data"]["shotnum"], list):
-        batch2 = {
-            "e_data": all_data["e_data_rot"][
-                config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :
-            ],
-            "e_amps": all_data["e_amps_rot"][
-                config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :
-            ],
-            "noise_e": all_data["noiseE_rot"][
-                config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :
-            ],
-            "i_data": all_data["i_data"],
-            "i_amps": all_data["i_amps"],
-            "noise_i": all_data["noiseI"][config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :],
-        }
-        actual_data = {"b1": batch1, "b2": batch2}
-    else:
-        actual_data = batch1
+    actual_data = build_angular_batch(config, all_data)
+    batch1 = actual_data["b1"] if isinstance(config["data"]["shotnum"], list) else actual_data
 
     previous_weights = None
     total_epochs = 0

--- a/tsadar/inverse/postprocess.py
+++ b/tsadar/inverse/postprocess.py
@@ -6,12 +6,11 @@ import time, tempfile, mlflow, os, copy
 
 import numpy as np
 import jax
-from equinox import filter_jit
 
 from tsadar.utils.plotting import plotters
 from .loss_function import LossFunction
 from tsadar.core.modules.ts_params import IonParams
-from .loops import one_d_loop, unbatch_fitted_params
+from .loops import one_d_loop, unbatch_fitted_params, build_batch, build_angular_batch
 from tsadar.core.thomson_diagnostic import ThomsonScatteringDiagnostic
 
 
@@ -59,49 +58,28 @@ def recalculate_with_chosen_weights(
     }
     sqdevs = {"ion": np.zeros(all_data["i_data"].shape), "ele": np.zeros(all_data["e_data"].shape)}
 
-    if config["data"]["load_ele_spec"]:
-        sigmas = np.zeros((all_data["e_data"].shape[0], num_params))
-        fits["ele"]["spec_comps"] = np.ones(
-            [
-                all_data["e_data"].shape[0],
-                max(
-                    config["parameters"]["general"]["Te_gradient"]["num_grad_points"],
-                    config["parameters"]["general"]["ne_gradient"]["num_grad_points"],
-                ),
-                all_data["e_data"].shape[1] * config["other"]["points_per_pixel"],
-                len(sa["sa"]),
-            ]
-        )
-    else:
-        fits["ele"]["spec_comps"] = np.zeros(all_data["e_data"].shape)
-    if config["data"]["load_ion_spec"]:
-        sigmas = np.zeros((all_data["i_data"].shape[0], num_params))
-        fits["ion"]["spec_comps"] = np.ones(
-            [
-                all_data["i_data"].shape[0],
-                max(
-                    config["parameters"]["general"]["Te_gradient"]["num_grad_points"],
-                    config["parameters"]["general"]["ne_gradient"]["num_grad_points"],
-                ),
-                all_data["i_data"].shape[1] * config["other"]["points_per_pixel"],
-                len(sa["sa"]),
-            ]
-        )
-    else:
-        fits["ion"]["spec_comps"] = np.zeros(all_data["i_data"].shape)
+    for species, data_key in (("ele", "e_data"), ("ion", "i_data")):
+        if config["data"][f"load_{species}_spec"]:
+            sigmas = np.zeros((all_data[data_key].shape[0], num_params))
+            fits[species]["spec_comps"] = np.ones(
+                [
+                    all_data[data_key].shape[0],
+                    max(
+                        config["parameters"]["general"]["Te_gradient"]["num_grad_points"],
+                        config["parameters"]["general"]["ne_gradient"]["num_grad_points"],
+                    ),
+                    all_data[data_key].shape[1] * config["other"]["points_per_pixel"],
+                    len(sa["sa"]),
+                ]
+            )
+        else:
+            fits[species]["spec_comps"] = np.zeros(all_data[data_key].shape)
 
     background_subtract = config["data"]["background"]["bg_subtract"]
     for i_batch, inds in enumerate(batch_indices):
-        batch = {
-                "e_data": all_data["e_data"][inds]-all_data["noiseE"][inds] if background_subtract else all_data["e_data"][inds],
-                "e_amps": all_data["e_amps"][inds],
-                "i_data": all_data["i_data"][inds]-all_data["noiseI"][inds] if background_subtract else all_data["i_data"][inds],
-                "i_amps": all_data["i_amps"][inds],
-                "noise_e": all_data["noiseE"][inds] if not background_subtract else 0.0,
-                "noise_i": all_data["noiseI"][inds] if not background_subtract else 0.0,
-            }
+        batch = build_batch(all_data, inds, background_subtract)
 
-        loss, sqds, ThryE, ThryI, params = loss_fn.array_loss(fitted_weights[i_batch], batch)
+        loss, sqds, ThryE, ThryI, _ = loss_fn.array_loss(fitted_weights[i_batch], batch)
 
         if config["plotting"]["detailed_breakdown"]:
             ts_diag = ThomsonScatteringDiagnostic(config, sa)
@@ -119,11 +97,10 @@ def recalculate_with_chosen_weights(
             fits["ion"]["detailed_axis"] = lamAxisI_raw[0]
 
         if calc_sigma:
-            hess = loss_fn.h_loss_wrt_params(fitted_weights[i_batch], batch)
             try:
                 hess = loss_fn.h_loss_wrt_params(fitted_weights[i_batch], batch)
-            except:
-                print("Error calculating Hessian, no hessian based uncertainties have been calculated")
+            except Exception as e:
+                print(f"Error calculating Hessian, no hessian based uncertainties have been calculated: {e}")
                 calc_sigma = False
 
         losses[inds] = loss
@@ -131,9 +108,6 @@ def recalculate_with_chosen_weights(
         sqdevs["ele"][inds] = sqds["ele"]
         sqdevs["ion"][inds] = sqds["ion"]
 
-        if config["optimizer"]["loss_method"] =='covar':
-            sqdevs["ele"][inds] = sqds["ele"]
-            sqdevs["ion"][inds] = sqds["ion"]
         if calc_sigma:
             sigmas[inds] = get_sigmas(hess, config["optimizer"]["batch_size"])
             # print(f"Number of 0s in sigma: {len(np.where(sigmas==0)[0])}") number of negatives?
@@ -166,7 +140,6 @@ def get_sigmas(hess: Dict, batch_size: int) -> Dict:
         for species in hess.keys()
         for key in hess[species].keys()
     }
-    # sizes = {key: hess[key][key].shape[1] for key in keys}
     actual_num_params = sum([v for k, v in sizes.items()])
     sigmas = np.zeros((batch_size, actual_num_params))
 
@@ -182,30 +155,8 @@ def get_sigmas(hess: Dict, batch_size: int) -> Dict:
                         k2 += 1
                 k1 += 1
 
-        # xc = 0
-        # for k1, param in enumerate(keys):
-        #     yc = 0
-        #     for k2, param2 in enumerate(keys):
-        #         if i > 0:
-        #             temp[k1, k2] = np.squeeze(hess[param][param2])[i, i]
-        #         else:
-        #             temp[xc : xc + sizes[param], yc : yc + sizes[param2]] = hess[param][param2][0, :, 0, :]
-        #
-        #         yc += sizes[param2]
-        #     xc += sizes[param]
-
-        # print(temp)
         inv = np.linalg.inv(temp)
-        # print(inv)
-
         sigmas[i, :] = np.sign(np.diag(inv)) * np.sqrt(np.abs(np.diag(inv)))
-        # for k1, param in enumerate(keys):
-        #     sigmas[i, xc : xc + sizes[param]] = np.diag(
-        #         np.sign(inv[xc : xc + sizes[param], xc : xc + sizes[param]])
-        #         * np.sqrt(np.abs(inv[xc : xc + sizes[param], xc : xc + sizes[param]]))
-        #     )
-        # print(sigmas[i, k1])
-        # change sigmas into a dictionary?
 
     return sigmas
 
@@ -267,13 +218,6 @@ def refit_bad_fits(config, sa, batch_indices, all_data, loss_fn, fitted_weights,
         temp_cfg = copy.deepcopy(config)
         temp_cfg["optimizer"]["batch_size"] = 1
 
-        def func(x):
-            # i, true_batch_size
-            if hasattr(x, "__len__"):
-                return {"val": x[(i - 1) % true_batch_size]}
-            else:
-                return {"val": x}
-
         def extract(x):
             # i, true_batch_size would idealy be inputs but i cant figure out how to pass variables
             if isinstance(x, list) or len(np.shape(x)) > 0:
@@ -298,8 +242,7 @@ def refit_bad_fits(config, sa, batch_indices, all_data, loss_fn, fitted_weights,
         )
         prev_weights = prev_weights.get_unnormed_params()
         prev_weights = jax.tree.map(lambda x: {"val": x}, prev_weights)
-        prev_weights["electron"]["fe"] = {"m": prev_weights["electron"]["m"]}
-        del prev_weights["electron"]["m"]
+        prev_weights["electron"]["fe"] = {"params": {"m": prev_weights["electron"].pop("m")}}
 
         temp_params = flatten(temp_cfg["parameters"])
         temp_params.update(flatten(prev_weights))
@@ -308,18 +251,10 @@ def refit_bad_fits(config, sa, batch_indices, all_data, loss_fn, fitted_weights,
         new_weights, _, loss_fn = one_d_loop(temp_cfg, all_data, sa, sample_indices, 1)
 
         inds = np.array([i])
-        batch = {
-            "e_data": all_data["e_data"][inds],
-            "e_amps": all_data["e_amps"][inds],
-            "i_data": all_data["i_data"][inds],
-            "i_amps": all_data["i_amps"][inds],
-            "noise_e": all_data["noiseE"][inds],
-            "noise_i": all_data["noiseI"][inds],
-        }
+        batch = build_batch(all_data, inds, config["data"]["background"]["bg_subtract"])
         loss, _, _, _, _ = loss_fn.array_loss(new_weights[0], batch)
 
         if loss < losses_init[i]:
-            del fitted_weights[(i - 1) // true_batch_size]["electron"]["m"]
             fitted_weights[(i - 1) // true_batch_size] = jax.tree.map(
                 insert,
                 fitted_weights[(i - 1) // true_batch_size],
@@ -365,41 +300,7 @@ def process_angular_data(config, batch_indices, all_data, all_axes, loss_fn, fit
             all_params[k][k2].append(batch_fitted_params[k][k2])
 
    # Prepare batch data
-    start, end = config["data"]["lineouts"]["start"], config["data"]["lineouts"]["end"]
-    # batch = {
-    #     "e_data": all_data["e_data"][start:end, :],
-    #     "e_amps": all_data["e_amps"][start:end, :],
-    #     "i_data": all_data["i_data"],
-    #     "i_amps": all_data["i_amps"],
-    #     "noise_e": all_data["noiseE"][start:end, :],
-    #     "noise_i": all_data["noiseI"][start:end, :],
-    # }
-    batch1 = {
-        "e_data": all_data["e_data"][config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :],
-        "e_amps": all_data["e_amps"][config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :],
-        "i_data": all_data["i_data"],
-        "i_amps": all_data["i_amps"],
-        "noise_e": all_data["noiseE"][config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :],
-        "noise_i": all_data["noiseI"][config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :],
-    }
-    if isinstance(config["data"]["shotnum"], list):
-        batch2 = {
-            "e_data": all_data["e_data_rot"][
-                config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :
-            ],
-            "e_amps": all_data["e_amps_rot"][
-                config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :
-            ],
-            "noise_e": all_data["noiseE_rot"][
-                config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :
-            ],
-            "i_data": all_data["i_data"],
-            "i_amps": all_data["i_amps"],
-            "noise_i": all_data["noiseI"][config["data"]["lineouts"]["start"] : config["data"]["lineouts"]["end"], :],
-        }
-        batch = {"b1": batch1, "b2": batch2}
-    else:
-        batch = batch1
+    batch = build_angular_batch(config, all_data)
 
     # Calculate losses and fits
     losses, sqdevs, fits_ele, _, params = loss_fn.array_loss(fitted_weights, batch)

--- a/tsadar/inverse/postprocess.py
+++ b/tsadar/inverse/postprocess.py
@@ -11,12 +11,19 @@ from equinox import filter_jit
 from tsadar.utils.plotting import plotters
 from .loss_function import LossFunction
 from tsadar.core.modules.ts_params import IonParams
-from .loops import one_d_loop
+from .loops import one_d_loop, unbatch_fitted_params
 from tsadar.core.thomson_diagnostic import ThomsonScatteringDiagnostic
 
 
 def recalculate_with_chosen_weights(
-    config: Dict, sa, sample_indices, all_data: Dict, loss_fn: LossFunction, calc_sigma: bool, fitted_weights: Dict
+    config: Dict,
+    sa,
+    sample_indices,
+    all_data: Dict,
+    loss_fn: LossFunction,
+    calc_sigma: bool,
+    fitted_weights: Dict,
+    num_params: int,
 ):
     """
     Gets parameters and the result of the full forward pass i.e. fits
@@ -28,6 +35,7 @@ def recalculate_with_chosen_weights(
         all_data: Dict- contains the electron data, ion data, and their respective amplitudes
         loss_fn: Instance of the LossFunction class
         fitted_weights: Dict- best values of the parameters returned by the minimizer
+        num_params: int- number of active fitted parameters, used to size the sigmas array
 
     Returns:
 
@@ -36,20 +44,6 @@ def recalculate_with_chosen_weights(
     losses = np.zeros_like(sample_indices, dtype=np.float64)
     sample_indices.sort()
     batch_indices = np.reshape(sample_indices, (-1, config["optimizer"]["batch_size"]))
-
-    # turn list of dictionaries into dictionary of lists
-    all_params = {k: defaultdict(list) for k in config["parameters"].keys()}
-
-    for _fw in fitted_weights:
-        batch_fitted_params, num_params = _fw.get_fitted_params(config["parameters"])
-        for k in batch_fitted_params.keys():
-            for k2 in batch_fitted_params[k].keys():
-                all_params[k][k2].append(batch_fitted_params[k][k2])
-
-    # concatenate all the lists in the dictionary
-    for k in all_params.keys():
-        for k2 in all_params[k].keys():
-            all_params[k][k2] = np.concatenate(all_params[k][k2])
 
     fits = {
         "ele": {
@@ -147,7 +141,7 @@ def recalculate_with_chosen_weights(
         fits["ele"]["total_spec"][inds] = ThryE
         fits["ion"]["total_spec"][inds] = ThryI
 
-    return losses, sqdevs, num_params, fits, sigmas, all_params
+    return losses, sqdevs, fits, sigmas
 
 
 def get_sigmas(hess: Dict, batch_size: int) -> Dict:
@@ -216,11 +210,14 @@ def get_sigmas(hess: Dict, batch_size: int) -> Dict:
     return sigmas
 
 
-def postprocess(config, sample_indices, all_data: Dict, all_axes: Dict, loss_fn, sa, fitted_weights):
+def postprocess(
+    config, sample_indices, all_data: Dict, all_axes: Dict, loss_fn, sa, fitted_weights, all_params=None, num_params=None
+):
     t1 = time.time()
 
     if config["other"]["extraoptions"]["spectype"] != "angular_full" and config["other"]["refit"]:
-        init_losses = refit_bad_fits(config, sa, sample_indices, all_data, loss_fn, fitted_weights)
+        init_losses = refit_bad_fits(config, sa, sample_indices, all_data, loss_fn, fitted_weights, num_params)
+        all_params, num_params = unbatch_fitted_params(config, fitted_weights)
     else:
         init_losses = []
 
@@ -235,7 +232,8 @@ def postprocess(config, sample_indices, all_data: Dict, all_axes: Dict, loss_fn,
 
         else:
             t1, final_params = process_data(
-                config, sample_indices, all_data, all_axes, loss_fn, fitted_weights, sa, init_losses, t1, td
+                config, sample_indices, all_data, all_axes, loss_fn, fitted_weights, sa, init_losses, t1, td,
+                all_params, num_params
             )
 
         mlflow.log_artifacts(td)
@@ -246,9 +244,9 @@ def postprocess(config, sample_indices, all_data: Dict, all_axes: Dict, loss_fn,
     return final_params
 
 
-def refit_bad_fits(config, sa, batch_indices, all_data, loss_fn, fitted_weights):
-    losses_init, sqdevs, num_params, fits, sigmas, all_params = recalculate_with_chosen_weights(
-        config, sa, batch_indices, all_data, loss_fn, False, fitted_weights
+def refit_bad_fits(config, sa, batch_indices, all_data, loss_fn, fitted_weights, num_params):
+    losses_init, sqdevs, fits, sigmas = recalculate_with_chosen_weights(
+        config, sa, batch_indices, all_data, loss_fn, False, fitted_weights, num_params
     )
 
     # refit bad fits
@@ -331,9 +329,9 @@ def refit_bad_fits(config, sa, batch_indices, all_data, loss_fn, fitted_weights)
     return losses_init
 
 
-def process_data(config, sample_indices, all_data, all_axes, loss_fn, fitted_weights, sa, losses_init, t1, td):
-    losses, sqdevs, num_params, fits, sigmas, all_params = recalculate_with_chosen_weights(
-        config, sa, sample_indices, all_data, loss_fn, config["other"]["calc_sigmas"], fitted_weights
+def process_data(config, sample_indices, all_data, all_axes, loss_fn, fitted_weights, sa, losses_init, t1, td, all_params, num_params):
+    losses, sqdevs, fits, sigmas = recalculate_with_chosen_weights(
+        config, sa, sample_indices, all_data, loss_fn, config["other"]["calc_sigmas"], fitted_weights, num_params
     )
 
     reduced_points = 1.0  # (used_points - num_params)*config["optimizer"]["batch_size"]


### PR DESCRIPTION
## Summary

Refactors `postprocess.py` to separate "what the fit produced" from "how it's turned into plots," fixes a latent crash in the previously-untested refit path, and lays groundwork for resuming a fit from a saved checkpoint.

- **Move parameter unbatching to the end of the fitter.** `recalculate_with_chosen_weights` used to both reorganize the batched fitted weights into flat per-lineout arrays *and* recompute spectra/uncertainty in one function. Extracted the reorganization into `unbatch_fitted_params()` (`loops.py`), now called once right after `one_d_loop` finishes in `fitter.py`, and threaded down through `postprocess()`/`process_data()` instead of being recomputed internally. Recomputed again after `refit_bad_fits` mutates the fitted weights, so refit results still show up correctly.
- **Deduplicate batch construction.** Added `build_batch()` and `build_angular_batch()` helpers in `loops.py` and replaced five copy-pasted versions of the same background-subtraction / lineout-slicing logic across `one_d_loop`, `multirun_angular_optax`, `recalculate_with_chosen_weights`, `process_angular_data`, `refit_bad_fits`, and `calc_vs_data.py`. Two of these call sites picked up a real (intentional) behavior change: `refit_bad_fits` now applies background subtraction to its refit batch like everywhere else does (it previously never did), and `calc_vs_data.py`'s interactive `forward_pass` now indexes with an array instead of a bare int, preserving the batch dimension consistent with the rest of the codebase.
- **General cleanup of `postprocess.py`**: removed dead code (duplicate Hessian call, a no-op conditional block, unused imports/variables, several stale commented-out blocks), narrowed a bare `except:`, and collapsed a duplicated ele/ion sizing block into one loop.
- **Fixed a crash in `refit_bad_fits`** that made the refit path (`other.refit: true`) fail on every run — it had no test coverage, so this had apparently never actually been exercised successfully:
  - A stray `del fitted_weights[idx]["electron"]["m"]` tried to dict-subscript a `ThomsonParams` pytree object, which was never valid.
  - The refit's updated `m` value was nested one level too shallow (`fe.m.val` instead of the real schema location `fe.params.m.val`), which silently produced a mismatched parameter tree and crashed `jax.tree.map` further down.
- **Added `tests/test_inverse/test_refit.py`**, an end-to-end regression test that forces the refit path (`refit_thresh` set low enough that every lineout is flagged) and verifies `fitter.fit()` completes with sane parameters. Confirmed it fails against the pre-fix code.
- **Persist fit results independently of postprocessing.** `fitter.fit()` now unconditionally logs `fitted_weights` (via `equinox.tree_serialise_leaves`, restorable into a fresh `ThomsonParams` skeleton built from the same config) and `all_params` (as the same CSV artifact `process_data` already produced) to mlflow right after the fit completes, before `postprocess()` runs. Added `config["other"]["run_postprocess"]` (default `True`) to make the postprocessing/plotting step itself skippable.

## Notes / follow-ups

- `run_postprocess: false` is currently only supported for non-angular fits — angular fits don't compute `all_params` at the fitter level yet, so this raises `NotImplementedError` rather than silently returning nothing useful.
- Restoring a saved `fitted_weights.eqx` into a live `ThomsonParams` object for warm-starting a new fit is not wired up yet — this PR only adds the save side.
- Set as a separate PR to avoid confusion with further added features